### PR TITLE
Show 'bundle confirmed' in history for confirmed reattaches instead of pending

### DIFF
--- a/lib/commands/history.js
+++ b/lib/commands/history.js
@@ -44,18 +44,18 @@ const setupHistoryCommand = (data, iotajs, vorpal) => {
       (biggest, bundle) => biggest > bundle[0].value ? biggest : bundle[0].value,
       0
     ) + '';
-    const persistences = transfers
-      .reduce(function (a, b) {
-        if (b.persistence && a.indexOf(b.bundle) == -1) {
-          a.push(b.bundle)
-        }
-        return a;
-      }, []);
+    const persistences = transfers.reduce(
+      (persists, bundle) => {
+      if (bundle[0].persistence && persists.indexOf(bundle[0].bundle) === -1) {
+        persists.push(bundle[0].bundle);
+      }
+      return persists;
+    }, []);
     transfers.forEach((bundle, index) => {
       const shortAddress = bundle[0].address.slice(0, 6);
       const persisted = bundle[0].persistence ? bundle[0].persistence : false;
       let reattachConfirmed = false;
-      if (!persisted && persistences.indexOf(bundle[0].bundle)) {
+      if (!persisted && persistences.indexOf(bundle[0].bundle) !== -1) {
           reattachConfirmed = true;
       }
       const shortHash = bundle[0].hash.slice(0, 6);

--- a/lib/commands/history.js
+++ b/lib/commands/history.js
@@ -11,7 +11,7 @@ const setupHistoryCommand = (data, iotajs, vorpal) => {
   const showSpecificItem = (hash, callback) => {
     // The history command identifies every bundle by the hash of the first tx in it.
     const matchingBundles = data.accountData.transfers.filter(
-      bundle => bundle[0].hash.indexOf(hash.toUpperCase()) !== -1
+      bundle => bundle[0].hash.indexOf(String(hash).toUpperCase()) !== -1
     );
 
     if (matchingBundles.length === 0) {
@@ -44,10 +44,20 @@ const setupHistoryCommand = (data, iotajs, vorpal) => {
       (biggest, bundle) => biggest > bundle[0].value ? biggest : bundle[0].value,
       0
     ) + '';
-
+    const persistences = transfers
+      .reduce(function (a, b) {
+        if (b.persistence && a.indexOf(b.bundle) == -1) {
+          a.push(b.bundle)
+        }
+        return a;
+      }, []);
     transfers.forEach((bundle, index) => {
       const shortAddress = bundle[0].address.slice(0, 6);
       const persisted = bundle[0].persistence ? bundle[0].persistence : false;
+      let reattachConfirmed = false;
+      if (!persisted && persistences.indexOf(bundle[0].bundle)) {
+          reattachConfirmed = true;
+      }
       const shortHash = bundle[0].hash.slice(0, 6);
       const time = moment.unix(bundle[0].timestamp).fromNow();
       const value = bundle[0].value;
@@ -57,7 +67,7 @@ const setupHistoryCommand = (data, iotajs, vorpal) => {
         ? leftPad('address', 13)
         : thisCategorizeTransfer.length > 0 ? 'spending from' : leftPad('receiving to', 13);
 
-      vorpal.log(`${index < 9 ? ' ' : ''}${index+1}: ${chalk.yellow(shortHash)} - ${type} ${shortAddress} - ${leftPad(value, biggestValue.length)} - ${persisted ? chalk.green('confirmed') : chalk.yellow('pending  ')} - ${time}`);
+      vorpal.log(`${index < 9 ? ' ' : ''}${index+1}: ${chalk.yellow(shortHash)} - ${type} ${shortAddress} - ${leftPad(value, biggestValue.length)} - ${persisted ? chalk.green('confirmed       ') : reattachConfirmed ? chalk.cyan('bundle confirmed') : chalk.yellow('pending         ')} - ${time}`);
     });
     vorpal.log(chalk.cyan('\nTo see more information on a specific transaction, provide a hash next time.\n'));
 


### PR DESCRIPTION
If a pending transaction has been confirmed via a reattachment (or a reattachment was confirmed in the original tx) show 'bundle confirmed' in `history`

also prevent a crash when a user accidentally enters just a number (forgetting the -n first) with the `history` command 