### PR TITLE
Bump iota.lib.json to 0.4.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -624,9 +624,9 @@
             "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ="
         },
         "iota.lib.js": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/iota.lib.js/-/iota.lib.js-0.4.3.tgz",
-            "integrity": "sha512-yev1WRCvggQFa8HdfRFHtwnle+mtU14D9DiV6HQh04Q+AzGxBmTjIrtXpPGDlicFv4wX3dd3jr4w7rlGFUOerg==",
+            "version": "0.4.6",
+            "resolved": "https://registry.npmjs.org/iota.lib.js/-/iota.lib.js-0.4.6.tgz",
+            "integrity": "sha1-R6/cA9V8f1XS9Y8GjbSS32vG6bs=",
             "requires": {
                 "async": "2.6.0",
                 "bignumber.js": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     },
     "scripts": {
         "lint": "node_modules/eslint/bin/eslint.js -c .eslintrc.json index.js",
-        "test": "echo \"Error: no test specified\" && exit 1"
+        "test": "echo \"Error: no test specified\" && exit 1",
+        "cli": "node index.js"
     },
     "repository": {
         "type": "git",
@@ -35,7 +36,7 @@
         "chalk": "^1.1.3",
         "eslint": "^3.15.0",
         "install": "^0.8.7",
-        "iota.lib.js": "^0.4.0",
+        "iota.lib.js": "^0.4.6",
         "json5": "^0.5.1",
         "left-pad": "^1.1.3",
         "lodash": "^4.17.4",


### PR DESCRIPTION
Since the promote command requires promote capabilities
in the core API.

Also adds a `cli` script so that you can `npm run cli`