### PR TITLE
Fix/issue 36 special characters in hostname

### DIFF
--- a/lib/commands/node.js
+++ b/lib/commands/node.js
@@ -32,7 +32,7 @@ const setupNodeCommand = (data, iotajs, refreshAccountData, refreshServerInfo, v
 
       iotajs.changeNode({host, port});
       if (host !== 'http://localhost') {
-        vorpal.log('This may take a few seconds for a remote node.  Did you turn on remote access?');
+        vorpal.log(`Changing node to ${host}:${port}. This may take a few seconds for a remote node.  Did you turn on remote access?`);
       }
 
       data.minWeightMagnitude = 14;

--- a/lib/commands/node.js
+++ b/lib/commands/node.js
@@ -18,7 +18,7 @@ const setupNodeCommand = (data, iotajs, refreshAccountData, refreshServerInfo, v
       const defaultPort = 14265;
       const regex = args.address.indexOf('[') !== -1
         ? /(http[s]?:\/\/)?(\[[\w\d:]+\])(:)?([0-9]*)?/
-        : /(http[s]?:\/\/)?([^:]+)(:)?([0-9]*)?/;
+        : /(http[s]?:\/\/)?([^:^/]+)(:)?([0-9]*)?/;
       const parts = args.address.match(regex);
       const protocol = parts[1] || defaultProtocol;
       const hostname = parts[2];

--- a/lib/commands/node.js
+++ b/lib/commands/node.js
@@ -18,7 +18,7 @@ const setupNodeCommand = (data, iotajs, refreshAccountData, refreshServerInfo, v
       const defaultPort = 14265;
       const regex = args.address.indexOf('[') !== -1
         ? /(http[s]?:\/\/)?(\[[\w\d:]+\])(:)?([0-9]*)?/
-        : /(http[s]?:\/\/)?([\w\d.]+)(:)?([0-9]*)?/;
+        : /(http[s]?:\/\/)?([^:]+)(:)?([0-9]*)?/;
       const parts = args.address.match(regex);
       const protocol = parts[1] || defaultProtocol;
       const hostname = parts[2];


### PR DESCRIPTION
Fixes #36 

This change allows every character (except : and /) for a hostname. There is no need for narrowing the hostname selection to allowed domain name characters.

Additionally the node gets printed, so you can double check if it was the right node or if it has been expanded the right way.